### PR TITLE
[LB-CLI] Add command for creating Ontology.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-dependencies = ["Click", "numpy==1.24.0", "labelbox[data]"]
+dependencies = ["click", "numpy==1.24.0", "labelbox[data]"]
 
 setup(
     name="labelbox-cli",

--- a/src/commands/ontology.py
+++ b/src/commands/ontology.py
@@ -1,10 +1,10 @@
 import sys
 
 import click
-from labelbox import Client
+from labelbox import Client, MediaType
 
 
-@click.group
+@click.group()
 def ontology():
     """
     Command for interacting with Ontologies. Use subcommands to perform CRUD operation.
@@ -12,10 +12,10 @@ def ontology():
     pass
 
 
-@ontology.command()
-@click.argument("--ontology_id", nargs=1)
+@ontology.command("get")
+@click.argument("ontology_id", nargs=1)
 @click.pass_obj
-def get(client: Client, ontology_id: str):
+def get_ontology(client: Client, ontology_id: str):
     """
     Retrieve ontology by ID. Prints result into the console.
     """
@@ -24,17 +24,17 @@ def get(client: Client, ontology_id: str):
     sys.exit(0)
 
 
-@ontology.command()
+@ontology.command("list")
 @click.option(
     "--name_contains", required=True, help="Retrieves list of ontology matched by name."
 )
-@click.option("--n", default=10, help="List available ontologies.", show_default=True)
+@click.option("--n", default=5, help="List available ontologies.", show_default=True)
 @click.pass_obj
-def list(client: Client, name_contains: str, n: int):
+def list_ontologies(client: Client, name_contains: str, n: int):
     """
     List available ontologies in the workspace. By default print only first 10.
     """
-    ontologies = list(client.get_ontologies(name_contains=name_contains))
+    ontologies = client.get_ontologies(name_contains=name_contains)
 
     # Apperantly Click for some reasons cannot convert generators into lists
     # hence this ugly workaround
@@ -45,4 +45,46 @@ def list(client: Client, name_contains: str, n: int):
         if n == 0:
             break
 
+    sys.exit(0)
+
+
+@ontology.command("create")
+@click.option("--name", required=True, help="Name for the ontology.")
+@click.option(
+    "--media_type", required=True, help="Ontology media type. Ex: image, video etc."
+)
+@click.option(
+    "--tools",
+    default="",
+    help='List of comma separated ID values. Ex: "toolId1,toolId2".',
+    type=str,
+)
+@click.option(
+    "--classifications",
+    "--c",
+    "classifications",
+    default="",
+    help='List of comma separated ID values. Ex: "classificationId1,classificationId2".',
+    type=str,
+)
+@click.pass_obj
+def create_ontology(
+    client: Client, name: str, media_type: str, tools: str, classifications: str
+):
+    """
+    Create new ontology from existing tools and classifications.
+    Creates empty ontology if no tools or classifications provided.
+    """
+    feature_schema_ids = (tools + "," + classifications).split(",")
+    feature_schema_ids = [
+        feature.strip() for feature in feature_schema_ids
+    ]  # remove whitespaces
+    feature_schema_ids = list(
+        filter(None, feature_schema_ids)
+    )  # remove empty strings from default values
+    ontology = client.create_ontology_from_feature_schemas(
+        name, feature_schema_ids, MediaType(media_type.upper())
+    )
+    click.echo("New ontology has been created:\n")
+    click.echo(ontology)
     sys.exit(0)

--- a/src/commands/ontology.py
+++ b/src/commands/ontology.py
@@ -1,0 +1,24 @@
+import sys
+
+import click
+from labelbox import Client
+
+
+@click.group
+def ontology():
+    """
+    Command for interacting with Ontologies. Use subcommands to perform CRUD operation.
+    """
+    pass
+
+
+@ontology.command()
+@click.argument("--ontology_id", nargs=1)
+@click.pass_obj
+def get(client: Client, ontology_id: str):
+    """
+    Retrieve ontology by ID. Prints result into the console.
+    """
+    ontology = client.get_ontology(ontology_id)
+    click.echo(ontology)
+    sys.exit(0)

--- a/src/commands/ontology.py
+++ b/src/commands/ontology.py
@@ -22,3 +22,27 @@ def get(client: Client, ontology_id: str):
     ontology = client.get_ontology(ontology_id)
     click.echo(ontology)
     sys.exit(0)
+
+
+@ontology.command()
+@click.option(
+    "--name_contains", required=True, help="Retrieves list of ontology matched by name."
+)
+@click.option("--n", default=10, help="List available ontologies.", show_default=True)
+@click.pass_obj
+def list(client: Client, name_contains: str, n: int):
+    """
+    List available ontologies in the workspace. By default print only first 10.
+    """
+    ontologies = list(client.get_ontologies(name_contains=name_contains))
+
+    # Apperantly Click for some reasons cannot convert generators into lists
+    # hence this ugly workaround
+    for ontology in ontologies:
+        click.echo(ontology)
+
+        n -= 1
+        if n == 0:
+            break
+
+    sys.exit(0)

--- a/src/commands/projects.py
+++ b/src/commands/projects.py
@@ -17,7 +17,7 @@ def projects():
     pass
 
 
-@projects.command()
+@projects.command("list")
 @click.option(
     "--match_projects",
     required=True,
@@ -28,7 +28,7 @@ def projects():
     "--n", default=10, help="List number of available projects.", show_default=True
 )
 @click.pass_obj
-def list(client: Client, match_projects: str, n: int):
+def list_projects(client: Client, match_projects: str, n: int):
     """
     Lists available projects with matching name.
     By default shows only first 10.
@@ -45,10 +45,10 @@ def list(client: Client, match_projects: str, n: int):
             break
 
 
-@projects.command()
+@projects.command("get")
 @click.argument("project_id", nargs=1)
 @click.pass_obj
-def get(client: Client, project_id: str):
+def get_project(client: Client, project_id: str):
     """
     Retrieves project by ID.
     """
@@ -56,7 +56,7 @@ def get(client: Client, project_id: str):
     click.echo(project)
 
 
-@projects.command()
+@projects.command("create")
 @click.option(
     "--name",
     required=True,
@@ -77,7 +77,7 @@ def get(client: Client, project_id: str):
     help="Project description. Default is empty string.",
 )
 @click.pass_obj
-def create(client: Client, name: str, description: str, project_type: str):
+def create_project(client: Client, name: str, description: str, project_type: str):
     """
     Creates new project.
     """
@@ -88,10 +88,10 @@ def create(client: Client, name: str, description: str, project_type: str):
     click.echo(f"New project has been created: \n{project}")
 
 
-@projects.command()
+@projects.command("delete")
 @click.argument("project_id", nargs=1)
 @click.pass_obj
-def delete(client: Client, project_id: str):
+def delete_project(client: Client, project_id: str):
     """
     Delete project by ID.
     """
@@ -100,7 +100,7 @@ def delete(client: Client, project_id: str):
     click.echo(f"Project with ID {project_id} has been deleted.")
 
 
-@projects.command()
+@projects.command("export")
 @click.argument("project_id", nargs=1)
 @click.option("--attachements", is_flag=True, default=False, show_default=True)
 @click.option("--metadata_fields", is_flag=True, default=False, show_default=True)
@@ -115,7 +115,7 @@ def delete(client: Client, project_id: str):
     help="Saves export results into file with the following format: project_export_epoch_time.json.",
 )
 @click.pass_obj
-def export(
+def export_export(
     client: Client,
     project_id: str,
     attachements: bool,

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ import click
 from click import Context
 from labelbox import Client
 
+from .commands.ontology import ontology
 from .commands.projects import projects
 from .utils import find_active_profile, read_json_file, write_json_file
 
@@ -43,3 +44,4 @@ def cli(ctx: Context):
 
 
 cli.add_command(projects)
+cli.add_command(ontology)


### PR DESCRIPTION
- New command has been added. Usage: 

```sh
labelbox ontology create --name "name" --media_type image --tools "id1,id2" --c "classificationId1,classificationId2"
```

- Refactored old logic due to some `click` internal conflicts between function names and command names.