### PR TITLE
[LB-CLI] Add delete ontology command

### DIFF
--- a/src/commands/ontology.py
+++ b/src/commands/ontology.py
@@ -88,3 +88,15 @@ def create_ontology(
     click.echo("New ontology has been created:\n")
     click.echo(ontology)
     sys.exit(0)
+
+
+@ontology.command("delete")
+@click.argument("ontology_id", nargs=1)
+@click.pass_obj
+def delete_ontology(client: Client, ontology_id: str):
+    """
+    Deletes unused ontology by ID.
+    """
+    client.delete_unused_ontology(ontology_id)
+    click.echo(f"Ontology with ID {ontology_id} has been deleted.")
+    sys.exit(0)

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,7 @@ def cli(ctx: Context):
     if CONFIG_FILE.is_file():
         content = read_json_file(CONFIG_FILE)
         profile = find_active_profile(content)
-        client = Client(api_key=profile["api_key"], endpoint=profile["endpoint"])  # type: ignore
+        client = Client(api_key=profile["api_key"], endpoint=profile["endpoint"], rest_endpoint=profile["rest_endpoint"])  # type: ignore
         ctx.obj = client
     else:
         click.echo("Looks like you have not configured any profiles yet.")
@@ -29,12 +29,16 @@ def cli(ctx: Context):
 
         api_key = input("Enter API key for your workspace: ")
         endpoint = input("Enter GraphQL endpoint. Leave blank if you don't have one: ")
+        rest_endpoint = input(
+            "Enter REST endpoint. Leave blank if you don't have one: "
+        )
         profile_name = input("Profile name. Ex: dev, stage, labeler etc: ")
         profile = {
             profile_name: {
                 "name": profile_name,
                 "api_key": api_key,
                 "endpoint": endpoint,
+                "rest_endpoint": rest_endpoint,
                 "active": True,
             }
         }


### PR DESCRIPTION
- New 'delete' command has been added for deleting **unused** Ontology. Usage example: 

```sh
labelbox ontology delete ONTOLOGY_ID
```

- `rest_endpoint` added to the profile. As some of the SDK calls require to have it.